### PR TITLE
Sell page: Add new item as seller

### DIFF
--- a/src/components/AddAuction/AddAuction.scss
+++ b/src/components/AddAuction/AddAuction.scss
@@ -82,6 +82,12 @@
 		font-size: 16px;
 		line-height: 24px;
 	}
+
+	.c-location {
+		width: 210px;
+		padding-right: 10px;
+		padding-left: 10px;
+	}
 }
 
 .description {
@@ -103,6 +109,7 @@
 
 .navigation {
 	text-align: center;
+	margin: 15px 0;
 
 	.back-button, .next-button {
 		width: 194px;

--- a/src/components/AddAuction/AddAuction.scss
+++ b/src/components/AddAuction/AddAuction.scss
@@ -1,0 +1,137 @@
+@import 'utils/Colors.scss';
+
+.stepper-box {
+	max-width: 40%;
+	margin: auto;
+	
+	.css-1u4zpwo-MuiSvgIcon-root-MuiStepIcon-root {
+		color: $extra-light-gray;
+		border: 1px solid $purple;
+		border-radius: 50%;
+
+		.css-117w1su-MuiStepIcon-text {
+			fill: $purple;
+		}
+	}
+
+	.css-1u4zpwo-MuiSvgIcon-root-MuiStepIcon-root.Mui-completed {
+		color: $purple;
+	}
+
+	.css-1u4zpwo-MuiSvgIcon-root-MuiStepIcon-root.Mui-active {
+		color: $purple;
+		border: 1px solid $purple;
+		border-radius: 50%;
+
+		.css-117w1su-MuiStepIcon-text {
+			fill: $white;
+		}
+	}
+
+	.css-vnkopk-MuiStepLabel-iconContainer {
+		padding-right: 0;
+	}
+}
+
+.price-box {
+	display: flex;
+
+	.price-icon {
+		border: 1px solid $border-color;
+		background-color: $extra-light-gray;
+		text-align: center;
+		width: 55px;
+		padding: 10px;
+		border-right: none;
+	}
+	
+	.start-price {
+		max-width: 86%;
+		border-left: none;
+	}
+}
+
+.flex-box {
+	display: flex;
+	flex-wrap: wrap;
+    align-content: center;
+    justify-content: center;
+    align-items: center;
+	margin-top: 10px;
+	margin-bottom: 10px;
+
+	:first-of-type[div] {
+		margin-right: 10px;
+	}
+
+	select, input[type=date] {
+		width: 190px;
+		padding: 10px 5px;
+		border: 1px solid $border-color;
+		background-color: $extra-light-gray;
+		outline: none;
+	}
+
+	.categories-list {
+		margin-right: 19px;
+	}
+
+	p {
+		color: $light-gray;
+		padding: 20px 50px;
+		font-size: 16px;
+		line-height: 24px;
+	}
+}
+
+.description {
+	padding: 10px 50px;
+	
+	textarea {
+		width: 400px;
+		height: 369px;
+		border-color: $border-color;
+		outline: none;
+    	background-color: $extra-light-gray;
+	}
+
+	p {
+		text-align: right;
+		color: $light-gray;
+	}
+}
+
+.navigation {
+	text-align: center;
+
+	.back-button, .next-button {
+		width: 194px;
+		background-color: $extra-light-gray;
+		font-weight: bold;
+		padding: 5px;
+		letter-spacing: 0.63px;
+	}
+
+	.back-button:hover, .next-button:hover {
+		background-color: $purple;
+		color: $white;
+		transition: all 0.3s;
+	}
+
+	.back-button {
+		margin-right: 10px;
+		border: 2px solid $border-color;
+
+		svg {
+			margin-right: 10px;
+		}
+	}
+
+	.next-button {
+		border: 2px solid $purple;
+
+		svg {
+			margin-left: 10px;
+		}
+	}
+}

--- a/src/components/AddAuction/AddAuction.tsx
+++ b/src/components/AddAuction/AddAuction.tsx
@@ -1,21 +1,21 @@
 import { useEffect, useState } from 'react'
 import { toast } from 'react-toastify';
+import moment from 'moment'
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Step, StepIcon, StepLabel, Stepper } from '@material-ui/core'
 
 import { Category } from 'interfaces/Category'
 import CategoryService from 'services/CategoryService'
-
-import './AddAuction.scss'
 import { Auction } from 'interfaces/Auction'
 import { Item } from 'interfaces/Item'
-import moment, { now } from 'moment'
 import { User } from 'interfaces/User'
 import { ShippingDetails } from 'interfaces/ShippingDetails'
 import AuthService from 'services/AuthService'
 import AuctionService from 'services/AuctionService';
 import { isValidAuctionSellingInput } from 'utils/Validations';
+
+import './AddAuction.scss'
 
 const AddAuction = () => {
 	const [categories, setCategories] = useState<Category[]>([])

--- a/src/components/AddAuction/AddAuction.tsx
+++ b/src/components/AddAuction/AddAuction.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
+import { toast } from 'react-toastify';
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Step, StepIcon, StepLabel, Stepper } from '@material-ui/core'
@@ -7,12 +8,26 @@ import { Category } from 'interfaces/Category'
 import CategoryService from 'services/CategoryService'
 
 import './AddAuction.scss'
+import { Auction } from 'interfaces/Auction'
+import { Item } from 'interfaces/Item'
+import moment, { now } from 'moment'
+import { User } from 'interfaces/User'
+import { ShippingDetails } from 'interfaces/ShippingDetails'
+import AuthService from 'services/AuthService'
+import AuctionService from 'services/AuctionService';
+import { isValidAuctionSellingInput } from 'utils/Validations';
 
 const AddAuction = () => {
 	const [categories, setCategories] = useState<Category[]>([])
 	const [subcategories, setSubcategories] = useState<Category[]>([])
 	const [selectedCategory, setSelectedCategory] = useState<Category>()
+	const [item, setItem] = useState<Item>()
+	const [auction, setAuction] = useState<Auction>()
 	const [step, setStep] = useState(0)
+	const [loggedUser, setLoggedUser] = useState<any>()
+	const [user, setUser] = useState<User>()
+	const [shippingInfo, setShippingInfo] = useState<ShippingDetails>()
+	const [error, setError] = useState({ message: '', hasError: false })
 
 	useEffect(() => {
 		CategoryService.getAllCategories()
@@ -21,23 +36,122 @@ const AddAuction = () => {
                     setCategories(response)
                 }
             })
+
+		setLoggedUser(AuthService.getCurrentUser())
 	}, [])
+
+	useEffect(() => {
+		AuthService.getUserById(loggedUser?.id, loggedUser?.authenticationToken)
+			.then(response => {
+				if (response) {
+					setUser(response)
+					setShippingInfo(response.shippingDetails)
+				}
+			})
+	}, [step])
 
 	const handleBackButtonClick = () => {
 		setStep(step-1)
-		console.log(step)
 	}
 
 	const handleNextButtonClick = () => {
 		setStep(step+1)
-		console.log(step)
+		validateInput()
 	}
 
-	const getOptions = (categories: any) => {
-        return categories.map((category: any) => <option key={category.categoryId} value={category.id}>{category.name}</option>);
-    };
+	const handleAuctionChange = (e: any) => {
+		setAuction(Object.assign({}, auction, { [e.target.name]: e.target.value }))
+	}
 
-    const categoriesOptions = useMemo(() => getOptions(categories), [categories]);
+	const handleItemChange = (e: any) => {
+		setItem(Object.assign({}, item, { [e.target.name]: e.target.value }))
+	}
+
+	const handleShippingInfoChange = (e: any) => {
+		setShippingInfo(Object.assign({}, shippingInfo, { [e.target.name]: e.target.value }))
+		validateInput()
+	}
+
+	const handlePhoneChange = (e: any) => {
+		setUser(Object.assign({}, user, { [e.target.name]: e.target.value }))
+		validateInput()
+	}
+
+	const handleSelectCategory = (e: any) => {
+		CategoryService.getCategory(e.target.value)
+            .then(response => {
+                if (response) {
+                    setSelectedCategory(response)
+					if (!response.subcategoryOf) {
+						getSubcategoriesByCategoryId(e.target.value)
+					}
+                }
+            })
+	}
+
+	const validateInput = () => {
+		const finalUserData = {
+            ...user,
+            shippingDetails: shippingInfo
+        }
+
+		const finalAuctionData = {
+            ...auction,
+            item: item,
+			seller: user,
+			category: selectedCategory
+        }
+		setError(isValidAuctionSellingInput(finalAuctionData, finalUserData))
+	}
+
+	const handleSubmit = () => {
+		const finalUserData = {
+            ...user,
+            shippingDetails: shippingInfo
+        }
+
+		const finalAuctionData = {
+            ...auction,
+            item: item,
+			seller: user,
+			category: selectedCategory
+        }
+		setError(isValidAuctionSellingInput(finalAuctionData, finalUserData))
+		if (!error.hasError) {
+			AuthService.update(
+				loggedUser.id,
+				finalUserData,
+				loggedUser.authenticationToken
+			)
+
+			AuctionService.addAuction(finalAuctionData, loggedUser.authenticationToken)
+			.then(
+				() => {
+					toast.success("Auction successfully added!", { hideProgressBar: true });
+					window.location.replace("/my_account/seller")
+				}
+			)
+		} else {
+			toast.error(error.message, { hideProgressBar: true });
+		}
+	}
+
+	const getSubcategoriesByCategoryId = (categoryId: string) => {
+		CategoryService.getSubcategoriesByCategoryId(categoryId)
+            .then(response => {
+                if (response) {
+                    setSubcategories(response)
+                }
+            })
+	}
+
+	const getStartDate = () => {
+		return auction?.startDate ? moment(auction?.startDate).toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10)
+	}
+
+	const getEndDate = () => {
+		return auction?.endDate ? moment(auction.endDate).toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10)
+	}
 	
     return (
 		<div className="container">
@@ -59,27 +173,27 @@ const AddAuction = () => {
 								<div className="input_wrap">
 									<label>What do you sell?</label>
 									<div className="input_field">
-										<input name="itemName" type="text" className="input" placeholder="Enter item name" />
+										<input onChange={handleItemChange} value={item?.name} name="name" type="text" className="input" placeholder="Enter item name" />
 									</div>
 								</div>
 								<div className="flex-box">
 									<div className="categories-list">
-										<select name="category">
-											<option value="">Select Category</option>
-											{categoriesOptions}
+										<select name="category" onChange={handleSelectCategory}>
+											<option disabled selected>Select Category</option>
+											{categories.map((category: any) => <option key={category.id} value={category.id}>{category.name}</option>)}
 										</select>
 									</div>
 									<div className="">
-										<select name="category">
-											<option value="">Select Category</option>
-											{categoriesOptions}
+										<select name="subcategory" onChange={handleSelectCategory}>
+											<option disabled selected>Select Subcategory</option>
+											{subcategories.map((subcategory: any) => <option key={subcategory.id} value={subcategory.id}>{subcategory.name}</option>)}
 										</select>
 									</div>
 								</div>
 								<div className="input-wrap description">
 									<label>Description</label>
 									<div className="input_field">
-										<textarea className="input"></textarea>
+										<textarea className="input" onChange={handleItemChange} value={item?.description} name="description"></textarea>
 										<p>100 words (700 characters)</p>
 									</div>
 								</div>
@@ -92,20 +206,20 @@ const AddAuction = () => {
 									<label>Your start price</label>
 									<div className="input_field price-box">
 										<div className="price-icon">$</div>
-										<input name="startPrice" type="number" className="input start-price" />
+										<input onChange={handleAuctionChange} value={auction?.startPrice} name="startPrice" type="number" className="input start-price" />
 									</div>
 								</div>
 								<div className="flex-box">
 									<div className="categories-list">
 										<label>Start Date</label>
 										<div className="input_field">
-											<input type="date" name="startDate"></input>
+											<input type="date" name="startDate" onChange={handleAuctionChange} value={getStartDate()}></input>
 										</div>
 									</div>
 									<div className="">
 										<label>End Date</label>
 										<div className="input_field">
-											<input type="date" name="endDate"></input>
+											<input type="date" name="endDate" onChange={handleAuctionChange} value={getEndDate()}></input>
 										</div>
 									</div>
 									<p>The auction will be automatically closed when the end time comes. The highest bid will win the auction.</p>
@@ -118,40 +232,43 @@ const AddAuction = () => {
 								<div className="input_wrap">
 									<label>Address</label>
 									<div className="input_field">
-										<input name="address" type="text" className="input" placeholder="Enter your address" />
+										<input onChange={handleShippingInfoChange} value={shippingInfo?.streetName} name="streetName" type="text" className="input" placeholder="Enter your address" />
 									</div>
 								</div>
 								<div className="flex-box">
-									<div className="categories-list">
-										<select name="category">
-											<option value="">Select City</option>
-											{categoriesOptions}
-										</select>
+									<div className="input_wrap c-location">
+										<label>City</label>
+										<div className="input_field">
+											<input onChange={handleShippingInfoChange} value={shippingInfo?.city} name="city" type="text" className="input" placeholder="Enter your city" />
+										</div>
 									</div>
-									<div className="">
-										<select name="category">
-											<option value="">Select Country</option>
-											{categoriesOptions}
-										</select>
+									<div className="input_wrap c-location">
+										<label>Country</label>
+										<div className="input_field">
+											<input onChange={handleShippingInfoChange} value={shippingInfo?.country} name="country" type="text" className="input" placeholder="Enter your country" />
+										</div>
 									</div>
 								</div>
 								<div className="input_wrap">
 									<label>Zip Code</label>
 									<div className="input_field">
-										<input name="zipCode" type="number" className="input" placeholder="Enter your zip code" />
+										<input onChange={handleShippingInfoChange} value={shippingInfo?.zipCode} name="zipCode" type="number" className="input" placeholder="Enter your zip code" />
 									</div>
 								</div>
 								<div className="input_wrap">
 									<label>Phone</label>
 									<div className="input_field">
-										<input name="phone" type="text" className="input" placeholder="Enter your phone" />
+										<input onChange={handlePhoneChange} value={user?.phoneNum} name="phoneNum" type="text" className="input" placeholder="Enter your phone" />
 									</div>
 								</div>
 							</> : ''
 						}
 						<div className="input_wrap navigation">
 							<button className="back-button" onClick={handleBackButtonClick}><FontAwesomeIcon icon={faChevronLeft}/> BACK</button>
-							<button className="next-button" onClick={handleNextButtonClick}>NEXT <FontAwesomeIcon icon={faChevronRight}/></button>
+							{step === 2 ? 
+								<button className="next-button" onClick={handleSubmit}>DONE</button> :
+								<button className="next-button" onClick={handleNextButtonClick}>NEXT <FontAwesomeIcon icon={faChevronRight}/></button>
+							}
 						</div> 
 					</div>
 				</div>

--- a/src/components/AddAuction/AddAuction.tsx
+++ b/src/components/AddAuction/AddAuction.tsx
@@ -45,7 +45,9 @@ const AddAuction = () => {
 			.then(response => {
 				if (response) {
 					setUser(response)
-					setShippingInfo(response.shippingDetails)
+					if (response.shippingDetails) {
+						setShippingInfo(response.shippingDetails)
+					}
 				}
 			})
 	}, [step])
@@ -232,33 +234,33 @@ const AddAuction = () => {
 								<div className="input_wrap">
 									<label>Address</label>
 									<div className="input_field">
-										<input onChange={handleShippingInfoChange} value={shippingInfo?.streetName} name="streetName" type="text" className="input" placeholder="Enter your address" />
+										<input onChange={handleShippingInfoChange} value={shippingInfo ? shippingInfo.streetName : ''} name="streetName" type="text" className="input" placeholder="Enter your address" />
 									</div>
 								</div>
 								<div className="flex-box">
 									<div className="input_wrap c-location">
 										<label>City</label>
 										<div className="input_field">
-											<input onChange={handleShippingInfoChange} value={shippingInfo?.city} name="city" type="text" className="input" placeholder="Enter your city" />
+											<input onChange={handleShippingInfoChange} value={shippingInfo ? shippingInfo.city : ''} name="city" type="text" className="input" placeholder="Enter your city" />
 										</div>
 									</div>
 									<div className="input_wrap c-location">
 										<label>Country</label>
 										<div className="input_field">
-											<input onChange={handleShippingInfoChange} value={shippingInfo?.country} name="country" type="text" className="input" placeholder="Enter your country" />
+											<input onChange={handleShippingInfoChange} value={shippingInfo ? shippingInfo.country: ''} name="country" type="text" className="input" placeholder="Enter your country" />
 										</div>
 									</div>
 								</div>
 								<div className="input_wrap">
 									<label>Zip Code</label>
 									<div className="input_field">
-										<input onChange={handleShippingInfoChange} value={shippingInfo?.zipCode} name="zipCode" type="number" className="input" placeholder="Enter your zip code" />
+										<input onChange={handleShippingInfoChange} value={shippingInfo ? shippingInfo.zipCode : ''} name="zipCode" type="number" className="input" placeholder="Enter your zip code" />
 									</div>
 								</div>
 								<div className="input_wrap">
 									<label>Phone</label>
 									<div className="input_field">
-										<input onChange={handlePhoneChange} value={user?.phoneNum} name="phoneNum" type="text" className="input" placeholder="Enter your phone" />
+										<input onChange={handlePhoneChange} value={user ? user.phoneNum : ''} name="phoneNum" type="text" className="input" placeholder="Enter your phone" />
 									</div>
 								</div>
 							</> : ''

--- a/src/components/AddAuction/AddAuction.tsx
+++ b/src/components/AddAuction/AddAuction.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useState } from 'react'
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { Step, StepIcon, StepLabel, Stepper } from '@material-ui/core'
+
+import { Category } from 'interfaces/Category'
+import CategoryService from 'services/CategoryService'
+
+import './AddAuction.scss'
+
+const AddAuction = () => {
+	const [categories, setCategories] = useState<Category[]>([])
+	const [subcategories, setSubcategories] = useState<Category[]>([])
+	const [selectedCategory, setSelectedCategory] = useState<Category>()
+	const [step, setStep] = useState(0)
+
+	useEffect(() => {
+		CategoryService.getAllCategories()
+            .then(response => {
+                if (response) {
+                    setCategories(response)
+                }
+            })
+	}, [])
+
+	const handleBackButtonClick = () => {
+		setStep(step-1)
+		console.log(step)
+	}
+
+	const handleNextButtonClick = () => {
+		setStep(step+1)
+		console.log(step)
+	}
+
+	const getOptions = (categories: any) => {
+        return categories.map((category: any) => <option key={category.categoryId} value={category.id}>{category.name}</option>);
+    };
+
+    const categoriesOptions = useMemo(() => getOptions(categories), [categories]);
+	
+    return (
+		<div className="container">
+			<div className="row">
+				<div className="col-12 col-sm-12 col-lg stepper-box">
+					<Stepper activeStep={step}>
+						<Step><StepLabel StepIconComponent={StepIcon}></StepLabel></Step>
+						<Step><StepLabel StepIconComponent={StepIcon}></StepLabel></Step>
+						<Step><StepLabel StepIconComponent={StepIcon}></StepLabel></Step>
+					</Stepper>
+				</div>
+			</div>
+			<div className="row">
+				<div className="col-12 col-sm-12 col-lg">
+					<div className="form">
+						{step === 0 ? 
+							<>
+								<div className="title">ADD ITEM</div>
+								<div className="input_wrap">
+									<label>What do you sell?</label>
+									<div className="input_field">
+										<input name="itemName" type="text" className="input" placeholder="Enter item name" />
+									</div>
+								</div>
+								<div className="flex-box">
+									<div className="categories-list">
+										<select name="category">
+											<option value="">Select Category</option>
+											{categoriesOptions}
+										</select>
+									</div>
+									<div className="">
+										<select name="category">
+											<option value="">Select Category</option>
+											{categoriesOptions}
+										</select>
+									</div>
+								</div>
+								<div className="input-wrap description">
+									<label>Description</label>
+									<div className="input_field">
+										<textarea className="input"></textarea>
+										<p>100 words (700 characters)</p>
+									</div>
+								</div>
+							</> : ''
+						}
+						{step === 1 ? 
+							<>
+								<div className="title">SET PRICES</div>
+								<div className="input_wrap">
+									<label>Your start price</label>
+									<div className="input_field price-box">
+										<div className="price-icon">$</div>
+										<input name="startPrice" type="number" className="input start-price" />
+									</div>
+								</div>
+								<div className="flex-box">
+									<div className="categories-list">
+										<label>Start Date</label>
+										<div className="input_field">
+											<input type="date" name="startDate"></input>
+										</div>
+									</div>
+									<div className="">
+										<label>End Date</label>
+										<div className="input_field">
+											<input type="date" name="endDate"></input>
+										</div>
+									</div>
+									<p>The auction will be automatically closed when the end time comes. The highest bid will win the auction.</p>
+								</div>
+							</> : ''
+						}
+						{step === 2 ? 
+							<>
+								<div className="title">LOCATION & SHIPPING</div>
+								<div className="input_wrap">
+									<label>Address</label>
+									<div className="input_field">
+										<input name="address" type="text" className="input" placeholder="Enter your address" />
+									</div>
+								</div>
+								<div className="flex-box">
+									<div className="categories-list">
+										<select name="category">
+											<option value="">Select City</option>
+											{categoriesOptions}
+										</select>
+									</div>
+									<div className="">
+										<select name="category">
+											<option value="">Select Country</option>
+											{categoriesOptions}
+										</select>
+									</div>
+								</div>
+								<div className="input_wrap">
+									<label>Zip Code</label>
+									<div className="input_field">
+										<input name="zipCode" type="number" className="input" placeholder="Enter your zip code" />
+									</div>
+								</div>
+								<div className="input_wrap">
+									<label>Phone</label>
+									<div className="input_field">
+										<input name="phone" type="text" className="input" placeholder="Enter your phone" />
+									</div>
+								</div>
+							</> : ''
+						}
+						<div className="input_wrap navigation">
+							<button className="back-button" onClick={handleBackButtonClick}><FontAwesomeIcon icon={faChevronLeft}/> BACK</button>
+							<button className="next-button" onClick={handleNextButtonClick}>NEXT <FontAwesomeIcon icon={faChevronRight}/></button>
+						</div> 
+					</div>
+				</div>
+			</div>
+		</div>
+	)
+}
+
+export default AddAuction

--- a/src/components/MyAccount/MyAccount.scss
+++ b/src/components/MyAccount/MyAccount.scss
@@ -222,6 +222,25 @@
 		transition: all 0.3s;
 	}
 
+	.add-button {
+		width: 130px;
+		border: 1px solid $border-color;
+		color: $purple;
+		background-color: $extra-light-gray;
+		padding: 5px 10px;
+		font-weight: bold;
+
+		svg {
+			margin-right: 10px;
+		}
+	}
+
+	.add-button:hover {
+		background-color: $purple;
+		color: $white;
+		transition: all 0.3s;
+	}
+
 	.table {
 
 		td,

--- a/src/components/MyAccount/SellerSection.tsx
+++ b/src/components/MyAccount/SellerSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import moment from "moment";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
 
 import shoppingCart from 'assets/shoppingCart.png';
@@ -8,7 +9,6 @@ import AuctionService from "services/AuctionService";
 import { Auction } from "interfaces/Auction";
 import NoOfBids from "shared/helper_components/NoOfBids";
 import HighestBid from "shared/helper_components/HighestBid";
-import { faPlus } from "@fortawesome/free-solid-svg-icons";
 
 
 const SellerSection = (props: any) => {

--- a/src/components/MyAccount/SellerSection.tsx
+++ b/src/components/MyAccount/SellerSection.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import moment from "moment";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Link } from "react-router-dom";
 
 import shoppingCart from 'assets/shoppingCart.png';
@@ -7,6 +8,7 @@ import AuctionService from "services/AuctionService";
 import { Auction } from "interfaces/Auction";
 import NoOfBids from "shared/helper_components/NoOfBids";
 import HighestBid from "shared/helper_components/HighestBid";
+import { faPlus } from "@fortawesome/free-solid-svg-icons";
 
 
 const SellerSection = (props: any) => {
@@ -56,6 +58,9 @@ const SellerSection = (props: any) => {
 			<div>
 				<button className={active ? 'seller-button active' : 'seller-button'} onClick={() => onButtonClick("active")}>Active</button>
 				<button className={sold ? 'seller-button active' : 'seller-button'} onClick={() => onButtonClick("sold")}>Sold</button>
+				{auctions.length !== 0 ? 
+					<Link to="/auctions/add/new"><button className="add-button"><FontAwesomeIcon icon={faPlus} />ADD ITEM</button></Link> : ''
+				}
 			</div>
 			<div className="table-section">
 				<table className="table">
@@ -106,7 +111,7 @@ const SellerSection = (props: any) => {
 								<p>You do not have any 
 									{active ? ' scheduled items for sale.' : ' sold items.'}
 								</p>
-								<button>START SELLING</button>
+								<Link to="/auctions/add/new"><button>START SELLING</button></Link>
 							</td> : ''
 					}
 					</tbody>

--- a/src/components/Product/SingleProduct.tsx
+++ b/src/components/Product/SingleProduct.tsx
@@ -139,7 +139,7 @@ const SingleProduct = (props: any) => {
 							{highestBid ?
 								<h4 className="prod-price">Start from <span>${highestBid}+</span></h4> : ''
 							}
-							{loggedUser ?
+							{loggedUser && user?.id !== item?.seller.id ?
 								<form onSubmit={handleSubmit}>
 									<div className="bid-section">
 										<input type="text" onChange={handleChange} value={bid?.bidAmount} name="bidAmount" placeholder="Enter your bid" required />

--- a/src/interfaces/ShippingDetails.tsx
+++ b/src/interfaces/ShippingDetails.tsx
@@ -4,5 +4,5 @@ export interface ShippingDetails {
 	city: string;
 	state: string;
 	country: string;
-	zipCode: number;
+	zipCode: string;
 }

--- a/src/pages/landing_page/LandingPage.tsx
+++ b/src/pages/landing_page/LandingPage.tsx
@@ -75,7 +75,7 @@ const LandingPage = () => {
 											<li key={category.id}><div className="category"><Link to={`/shop/${category.id}`}>{category.name}</Link></div></li>
 										)
 									})} 
-									<li><div className="category"><Link to={`/shop/all`}>All Categories</Link></div></li>
+									<li><div className="category"><Link to="/shop/all">All Categories</Link></div></li>
 								</ul> : '' 
 							}
 						</div>

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -13,6 +13,7 @@ import Shop from "components/Shop/Shop";
 import MyAccount from "components/MyAccount/MyAccount";
 
 import 'react-toastify/dist/ReactToastify.css';
+import AddAuction from "components/AddAuction/AddAuction";
 
 const Routes = () => {
 	return (
@@ -25,6 +26,7 @@ const Routes = () => {
 				<Route exact path="/about" component={About} />
 				<Route exact path="/privacy_policy" component={Privacy_Policy} />
 				<Route exact path="/auctions/:id" component={SingleProduct} />
+				<Route exact path="/auctions/add/new" component={AddAuction} />
 				<Route exact path="/login" component={Login} />
 				<Route exact path="/register" component={Registration} />
 				<Route exact path="/shop/:categoryId" component={Shop} />

--- a/src/services/AuctionService.tsx
+++ b/src/services/AuctionService.tsx
@@ -79,6 +79,15 @@ class AuctionService {
             .catch(() => console.log("An error occured while fetching the count per price."))
     }
 
+    addAuction = (auction: any, token: string) => {
+        return axios
+            .post(API_URL + "auctions/new", auction, HeaderConfig(token))
+            .then((response: any) => {
+                return response.data;
+            })
+            .catch(() => console.error("An error occured while saving the auction."));
+    }
+
     getBids = (auctionId: any, token: string) => {
         return axios
             .get(API_URL + `bids/${auctionId}`, HeaderConfig(token))

--- a/src/utils/Validations.tsx
+++ b/src/utils/Validations.tsx
@@ -1,8 +1,6 @@
 import { DATE_OF_BIRTH_EMPTY, EMAIL_EMPTY, EMAIL_INVALID, FIRST_NAME_EMPTY, GENDER_EMPTY, LAST_NAME_EMPTY, PASSWORD_EMPTY, PASSWORD_LENGTH, PHONE_NUMBER_EMPTY } from "constants/ErrorMessages";
-import { Auction } from "interfaces/Auction";
 import { LoginError } from "interfaces/LoginError";
 import { RegistrationError } from "interfaces/RegistrationError";
-import { User } from "interfaces/User";
 import moment from "moment";
 
 export const validateEmail = (email: string) => {
@@ -26,14 +24,18 @@ export const isValidRegisterInput = (registerData: any) => {
 export const isValidAuctionSellingInput = (auction: any, user: any) => {
 	const errors = { message: '', hasError: false }
 
-	if (!auction.item || auction.item.name.length === 0 
-		|| !auction.category || !auction.item.description
-		|| auction.item.description.length === 0 || !auction.startPrice
-		|| !auction.startDate || !auction.endDate || !user.shippingDetails.streetName
-		|| user.shippingDetails.streetName.length === 0 || !user.shippingDetails.city
-		|| user.shippingDetails.city.length === 0 || !user.shippingDetails.country
-		|| user.shippingDetails.country.length === 0 || !user.shippingDetails.zipCode 
-		|| !user.phoneNum) {
+	if (!auction.item || !auction.category || !auction.startPrice || !auction.startDate 
+		|| !auction.endDate || !user.shippingDetails || !user.phoneNum
+		|| !user.shippingDetails.streetName || !user.shippingDetails.city
+		|| !user.shippingDetails.country || !user.shippingDetails.zipCode) {
+
+		errors.message = "You have some empty required fields!"
+		errors.hasError = true
+		return errors
+
+	} else if (auction.item.name.length === 0 || auction.item.description.length === 0
+		|| user.shippingDetails.streetName.length === 0 || user.shippingDetails.city.length === 0 
+		|| user.shippingDetails.country.length === 0 || user.shippingDetails.zipCode.length === 0) {
 
 		errors.message = "You have some empty required fields!"
 		errors.hasError = true
@@ -41,6 +43,11 @@ export const isValidAuctionSellingInput = (auction: any, user: any) => {
 
 	} else if (auction.startDate > auction.endDate) {
 		errors.message = "Start date cannot be set higher than end date!"
+		errors.hasError = true
+		return errors
+
+	} else if (moment(auction.startDate).toISOString().slice(0, 10) < new Date().toISOString().slice(0, 10)) {
+		errors.message = "Start date cannot be set less than today!"
 		errors.hasError = true
 		return errors
 

--- a/src/utils/Validations.tsx
+++ b/src/utils/Validations.tsx
@@ -1,6 +1,9 @@
 import { DATE_OF_BIRTH_EMPTY, EMAIL_EMPTY, EMAIL_INVALID, FIRST_NAME_EMPTY, GENDER_EMPTY, LAST_NAME_EMPTY, PASSWORD_EMPTY, PASSWORD_LENGTH, PHONE_NUMBER_EMPTY } from "constants/ErrorMessages";
+import { Auction } from "interfaces/Auction";
 import { LoginError } from "interfaces/LoginError";
 import { RegistrationError } from "interfaces/RegistrationError";
+import { User } from "interfaces/User";
+import moment from "moment";
 
 export const validateEmail = (email: string) => {
 	return RegExp(/^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i).test(email)
@@ -18,6 +21,36 @@ export const isValidRegisterInput = (registerData: any) => {
 		return false
 	}
 	return true
+}
+
+export const isValidAuctionSellingInput = (auction: any, user: any) => {
+	const errors = { message: '', hasError: false }
+
+	if (!auction.item || auction.item.name.length === 0 
+		|| !auction.category || !auction.item.description
+		|| auction.item.description.length === 0 || !auction.startPrice
+		|| !auction.startDate || !auction.endDate || !user.shippingDetails.streetName
+		|| user.shippingDetails.streetName.length === 0 || !user.shippingDetails.city
+		|| user.shippingDetails.city.length === 0 || !user.shippingDetails.country
+		|| user.shippingDetails.country.length === 0 || !user.shippingDetails.zipCode 
+		|| !user.phoneNum) {
+
+		errors.message = "You have some empty required fields!"
+		errors.hasError = true
+		return errors
+
+	} else if (auction.startDate > auction.endDate) {
+		errors.message = "Start date cannot be set higher than end date!"
+		errors.hasError = true
+		return errors
+
+	} else if (moment(auction.endDate).toISOString().slice(0, 10) < new Date().toISOString().slice(0, 10)) {
+		errors.message = "End date cannot be set less than today!"
+		errors.hasError = true
+		return errors
+	}
+
+	return errors
 }
 
 export const validateRegisterData = (registerData: any) => {


### PR DESCRIPTION
Once the user chooses to add an additional item, the process of adding a new item should be triggered.

This process has 3 steps:
- adding the basic info
- adding price and dates
- adding the location of the item (the shipping part should be omitted for now) - if the user already has an address inside their profile, it should be pre-populated, but editable.